### PR TITLE
Update to Go 1.19.6

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.6'
           cache: true
 
       - run: make build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.3
+golang 1.19.6


### PR DESCRIPTION
Update to 1.19.6 because it fixes a bunch of CVEs.

[_Created by Sourcegraph batch change `jhchabran/update-to-go-1.19.6`._](https://sourcegraph.sourcegraph.com/users/jhchabran/batch-changes/update-to-go-1.19.6)